### PR TITLE
Bundle Exception

### DIFF
--- a/src/ThemeBundle.php
+++ b/src/ThemeBundle.php
@@ -6,6 +6,7 @@ use CodeIgniter\Files\FileCollection;
 use Tatter\Assets\Asset;
 use Tatter\Assets\Bundle;
 use Tatter\Themes\Entities\Theme;
+use UnexpectedValueException;
 
 /**
  * Theme Assets Bundle
@@ -33,6 +34,10 @@ final class ThemeBundle extends Bundle
         // Resolve the directory for the active theme
         $root      = rtrim(Asset::config()->directory, '\\/ ');
         $directory = $root . DIRECTORY_SEPARATOR . trim($theme->path, '/ ');
+
+        if (! is_dir($directory)) {
+            throw new UnexpectedValueException('Theme directory does not exist: ' . $directory);
+        }
 
         // Locate all CSS and JSS files in the them path
         $files = (new FileCollection())

--- a/tests/BundleTest.php
+++ b/tests/BundleTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Tatter\Themes\Models\ThemeModel;
 use Tatter\Themes\ThemeBundle;
 use Tests\Support\TestCase;
 
@@ -45,5 +46,15 @@ final class BundleTest extends TestCase
         ThemeBundle::createFromTheme(theme());
 
         $this->assertNotEmpty(cache()->getCacheInfo());
+    }
+
+    public function testFailsNoDirectory()
+    {
+        $theme = fake(ThemeModel::class);
+
+        $this->expectException('UnexpectedValueException');
+        $this->expectExceptionMessage('Theme directory does not exist: ');
+
+        ThemeBundle::createFromTheme($theme);
     }
 }


### PR DESCRIPTION
Improves error message when the bundle tries to use a theme with missing assets directory (mostly happens during testing).